### PR TITLE
Allow calling pthread_join from a non pthread thread

### DIFF
--- a/platform/vita/vita_osal.c
+++ b/platform/vita/vita_osal.c
@@ -236,15 +236,18 @@ pte_osResult pte_osThreadWaitForEnd(pte_osThreadHandle threadHandle)
 {
 	int status = 0;
 	pspThreadData *pThreadData = *(pspThreadData **)vitasdk_get_pthread_data(0);
-	SceUID evid = pThreadData->evid;
 	while (1)
 	{
-		unsigned int bits = 0;
-		sceKernelPollEventFlag(evid, PTHREAD_EVID_CANCEL, SCE_EVENT_WAITAND, &bits);
-
-		if (bits & PTHREAD_EVID_CANCEL)
+		// The current thread does not have to be a pthread thread
+		if (pThreadData)
 		{
-			return PTE_OS_INTERRUPTED;
+			unsigned int bits = 0;
+			sceKernelPollEventFlag(pThreadData->evid, PTHREAD_EVID_CANCEL, SCE_EVENT_WAITAND, &bits);
+
+			if (bits & PTHREAD_EVID_CANCEL)
+			{
+				return PTE_OS_INTERRUPTED;
+			}
 		}
 
 		SceUInt timeout = POLLING_DELAY_IN_us;


### PR DESCRIPTION
Non pthread threads are not cancellable. They don't need to check their cancellation flag.

----

If the thread was made by native function (sceKernelCreateThread), it cannot call the `pthread_join` for child thread
that this thread doesn't have TLS data for pthread calls.
this issue could make the trouble to calling some pthread functions

This pr will bypass the crash point of `pthread_join` that this section only uses for the canceling join request.