### PR TITLE
Reinitialize when calling pthread_create from non-pthread thread

### DIFF
--- a/platform/vita/vita_osal.c
+++ b/platform/vita/vita_osal.c
@@ -139,6 +139,13 @@ pte_osResult pte_osThreadCreate(pte_osThreadEntryPoint entryPoint,
                                 void *argv,
                                 pte_osThreadHandle* ppte_osThreadHandle)
 {
+	/* pthread_create was called by non-pthread thread */
+	if (*(pspThreadData **)vitasdk_get_pthread_data(0) == NULL) {
+		if (pte_osInit() != PTE_OS_OK) {
+			return PTE_OS_NO_RESOURCES;
+		}
+	}
+
 	SceUID thid;
 
 	if (stackSize < DEFAULT_STACK_SIZE_BYTES)


### PR DESCRIPTION
A native thread cannot have the TLS dataset for pthread-embedded process.
It makes the trouble at calling some pthread functions such as `pthread_join`
in non-pthread thread.

This simple hack will make the TLS data to non-pthread thread.

related #19