### PR TITLE
Use relative install paths for headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,24 +77,24 @@ endif()
 
 install(FILES
     pthread_public.h
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/include/
+    DESTINATION include
     RENAME pthread.h
 )
 
 install(FILES
     sched.h semaphore.h
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/include/
+    DESTINATION include
 )
 
 if(VITA)
   install(FILES
     platform/vita/pte_types.h
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/include/
+    DESTINATION include
   )
 elseif (PLATFORM_PSP)
   install(FILES
     platform/psp/pte_types.h
-    DESTINATION ${CMAKE_INSTALL_PREFIX}/include/
+    DESTINATION include
   )
 endif()
 


### PR DESCRIPTION
Using relative paths in the calls to `install` allows the same build to be installed to several location without reconfiguring the project. This enables flexibility similarly to autotools':
```
./configure --prefix=/
make install DESTDIR=/foo
make install DESTDIR=/bar
```

Without this change:
```
cmake -S . -B build -D CMAKE_INSTALL_PREFIX=/foo -D CMAKE_TOOLCHAIN_FILE=...
cmake --build build
cmake --install build # All files installed in /foo
cmake --install build --prefix /bar # Library installed in /bar, headers installed in /foo
```

With this change:
```
cmake -S . -B build -D CMAKE_INSTALL_PREFIX=/foo -D CMAKE_TOOLCHAIN_FILE=...
cmake --build build
cmake --install build # All files installed in /foo
cmake --install build --prefix /bar # All files installed in /bar
```