### PR TITLE
Quick fix for NULL for GCC14

### DIFF
--- a/pthread_public.h
+++ b/pthread_public.h
@@ -754,4 +754,9 @@ extern "C" {
 #undef PTE_LEVEL
 #undef PTE_LEVEL_MAX
 
+#ifdef NULL
+#undef NULL
+#define NULL 0
+#endif
+
 #endif /* PTHREAD_H */


### PR DESCRIPTION
Needed for GCC14. Wasn't needed for GCC13, but also compiles fine with this fix.
NULL is normally defined as (void*)0 but pthread_t is of type unsigned int. Compiler errors about, so I define NULL as 0 and that compiles well