### PR TITLE
move _POSIX_THREADS_INTERNAL to CFLAGS

### DIFF
--- a/platform/vita/Makefile
+++ b/platform/vita/Makefile
@@ -177,8 +177,8 @@ CC = arm-vita-eabi-gcc
 CXX = arm-vita-eabi-g++
 AR = arm-vita-eabi-ar
 
-CFLAGS = $(GLOBAL_CFLAGS) -Wl,-q -Wall -O3 -fno-strict-aliasing -I. -I../..
-CXXFLAGS = $(CFLAGS) -fexceptions -fno-rtti -Werror -D__CLEANUP_CXX -D_POSIX_THREADS_INTERNAL
+CFLAGS = $(GLOBAL_CFLAGS) -Wl,-q -Wall -O3 -fno-strict-aliasing -I. -I../.. -D_POSIX_THREADS_INTERNAL
+CXXFLAGS = $(CFLAGS) -fexceptions -fno-rtti -Werror -D__CLEANUP_CXX
 ASFLAGS = $(CFLAGS)
 
 ifeq ($(CLEANUP_TYPE),CPPXX)


### PR DESCRIPTION
in _pthreadtypes.h
pthread_t is defined as a pointer for internal source code
```c
#ifdef _POSIX_THREADS_INTERNAL
typedef struct pthread_t_ * pthread_t;            /* identify a thread */
#else
typedef __uint32_t pthread_t;            /* identify a thread */
#endif
```

in pte_new.c:
pthread_t is used like a pointer
```c
pthread_t
pte_new (void)
{
  pthread_t t = NULL;
  pthread_t nil = NULL;
```

but in the makefile the define is only set for CXXFLAGS which dont apply on c files+